### PR TITLE
Issue #135 hide draft posts from the mastori listing

### DIFF
--- a/blog/tests/test_views.py
+++ b/blog/tests/test_views.py
@@ -1,5 +1,7 @@
 from django.test import TestCase
 from rest_framework.test import APITestCase
+from blog.models import Stori, Category
+import json
 
 # Create your tests here.
 
@@ -7,3 +9,24 @@ from rest_framework.test import APITestCase
     
 #     def test_storilist(self):
 #         self.client
+
+class TestStoriList(TestCase):
+    def setUp(self):
+        self.test_category = Category.objects.create(name="Test Category")
+
+        Stori.objects.create(title="Test 1", slug="test-1", description="Test 1", content="Story 1", category=self.test_category)
+        Stori.objects.create(title="Test 2", slug="test-2", description="Test 2", content="Story 2", status="Published", category=self.test_category)
+
+    """
+    Test the /mastori/ endpoint to ascertain whether
+    only published blogs are returned
+    """
+    def test_only_published_stori_returned(self):
+        response = self.client.get("/mastori/")
+        
+        self.assertEqual(response.status_code, 200)
+        mastori_json = json.loads(response.content)
+
+        # Expecting only one object, the one with 'Published' status to be returned
+        self.assertEqual(len(mastori_json), 1)
+        self.assertTrue(mastori_json[0]['status']=="Published")

--- a/blog/views.py
+++ b/blog/views.py
@@ -84,7 +84,7 @@ class CategoryViewset(viewsets.ModelViewSet):
 class StoriViewset(viewsets.ModelViewSet):
     """"blog/stori viewset"""
     serializer_class = BlogSerializer
-    queryset = Stori.objects.all()
+    queryset = Stori.objects.filter(status="Published")
     permission_classes = [IsAuthenticatedOrReadOnly]
 
     def perform_create(self, serializer):


### PR DESCRIPTION
# Fixes the bug listing all blogs, including drafts

This fixes the listing of blogs that were listed despite having a draft status. It filters the objects to only published ones from the dataset before processing and returning the list.

Fixes #135 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

[![CI Django & Postgres Tests](https://github.com/SpaceyaTech/blog/actions/workflows/django-postgres-ci.yml/badge.svg)](https://github.com/SpaceyaTech/blog/actions/workflows/django-postgres-ci.yml)

[![Jambo](https://github.com/SpaceyaTech/mastori/actions/workflows/jambo.yaml/badge.svg)](https://github.com/SpaceyaTech/mastori/actions/workflows/jambo.yaml)


**Test Configuration**:

```sql
          python manage.py migrate
          python manage.py test
```

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

