### PR TITLE
Issue 145 unauthorized session can create categories

### DIFF
--- a/blog/tests/test_views.py
+++ b/blog/tests/test_views.py
@@ -1,6 +1,9 @@
 from django.test import TestCase
-from rest_framework.test import APITestCase
 from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase, APIClient
+from rest_framework_simplejwt.tokens import RefreshToken
+from accounts.models import User
 from blog.models import Stori, Category
 import json
 
@@ -32,3 +35,35 @@ class TestStoriList(TestCase):
         # Expecting only one object, the one with 'Published' status to be returned
         self.assertEqual(len(mastori_json), 1)
         self.assertTrue(mastori_json[0]['status']=="Published")
+
+class TestCategoryCreation(TestCase):
+    """
+    Test the categories endpoint to ascertain whether
+    only logged in users can create categories
+    """
+    def test_only_logged_in_users_create_category(self):
+        test_user = User.objects.create_user(
+            first_name="Zaphod", 
+            last_name="Beeblebrox", 
+            email="hitchhiker@local.com", 
+            username="hitchhiker", 
+            password="Beeblebrox42")
+        
+        test_data = {
+            'name': 'Test Category 1'
+        }
+
+        categories_url = reverse('categories-list')
+        # This is an UNAUTHORIZED post that bypasses the created user above
+        response = self.client.post(categories_url, test_data)
+        # Check whether the category has NOT been created
+        self.assertEqual(response.status_code, 401)
+
+        c = APIClient()
+        refresh = RefreshToken.for_user(test_user)
+        c.credentials(HTTP_AUTHORIZATION=f'Bearer {refresh.access_token}')
+        # This is an AUTHORIZED post that gets a token for the created user
+        response = c.post(categories_url, test_data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        
+

--- a/blog/tests/test_views.py
+++ b/blog/tests/test_views.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 from rest_framework.test import APITestCase
+from django.urls import reverse
 from blog.models import Stori, Category
 import json
 
@@ -22,7 +23,8 @@ class TestStoriList(TestCase):
     only published blogs are returned
     """
     def test_only_published_stori_returned(self):
-        response = self.client.get("/mastori/")
+        mastori_url = reverse('mastori-list')
+        response = self.client.get(mastori_url)
         
         self.assertEqual(response.status_code, 200)
         mastori_json = json.loads(response.content)

--- a/blog/views.py
+++ b/blog/views.py
@@ -26,9 +26,12 @@ class CategoryViewset(viewsets.ModelViewSet):
     def get_permissions(self):
         # admin is allowed to destroy and update a category
         if self.action == 'destroy' or self.action == "update":
-            self.permission_classes = [IsAdminUser]
-        # anyone can create, retrieve and list all categories
-        elif self.action == 'retrieve' or self.action == "create" or self.action == "list":
+            self.permission_classes = [IsAdminUser, IsAuthenticated]
+        # anyone can create a category if logged in
+        elif self.action == "create":
+            self.permission_classes = [IsAuthenticated]
+        # anyone can retrieve and list all categories
+        elif self.action == 'retrieve' or self.action == "list":
             self.permission_classes = [AllowAny]
         return super().get_permissions()
     


### PR DESCRIPTION
# Description

Limits the creation of categories to users who are logged in only.

Fixes #145 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

[![CI Django & Postgres Tests](https://github.com/SpaceyaTech/blog/actions/workflows/django-postgres-ci.yml/badge.svg)](https://github.com/SpaceyaTech/blog/actions/workflows/django-postgres-ci.yml)


**Test Configuration**:

```sql
          python manage.py migrate
          python manage.py test
```

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

