### PR TITLE
✨: Added swagger for API documentation

### DIFF
--- a/CMS/settings.py
+++ b/CMS/settings.py
@@ -52,6 +52,10 @@ INSTALLED_APPS = [
     # Adding djangorestframework to the poject
     'rest_framework',
     'phonenumber_field',
+    'drf_spectacular',
+    'rest_framework_swagger',
+
+
     #Adding the django filters module
     'django_filters', 
     # for blacklisting used refresh token
@@ -175,6 +179,9 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework_simplejwt.authentication.JWTAuthentication',
     ),
+
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+
     'DEFAULT_THROTTLE_CLASSES': [
         'rest_framework.throttling.UserRateThrottle',
         'blog.throttles.BlogRateThrottle',
@@ -218,6 +225,14 @@ SIMPLE_JWT = {
     'SLIDING_TOKEN_REFRESH_EXP_CLAIM': 'refresh_exp',
     'SLIDING_TOKEN_LIFETIME': timedelta(minutes=5),
     'SLIDING_TOKEN_REFRESH_LIFETIME': timedelta(days=1),
+}
+
+# Spectatular settings
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'Mastori',
+    'DESCRIPTION': 'Mastori is a community-driven open-source project that aims to provide a simple and efficient blogging platform built with the Django Rest Framework. ',
+    'VERSION': '1.0.0',
+    'SERVE_INCLUDE_SCHEMA': False,
 }
 
 # CKEDITOR configurations

--- a/CMS/urls.py
+++ b/CMS/urls.py
@@ -3,6 +3,7 @@ from django.contrib import admin
 from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 admin.site.site_header = "SpaceYaTech CMS Admin"
 admin.site.site_title = "SpaceYaTech Admin Portal"
@@ -17,6 +18,11 @@ urlpatterns = [
     path('',include('blog.urls')),
 
     path('ckeditor/', include('ckeditor_uploader.urls')),
+
+     # Add the Spectacular views for Swagger documentation
+    path('schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('schema/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+
 ] + static(settings.MEDIA_URL,
            document_root=settings.MEDIA_ROOT)
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ The project is designed to help developers build their own blogging website or a
     /account/id/stori/id/reaction/id/
 ```
 
+## Documentation
+```sql
+    /schema/docs/
+
+```
+
 # Features
 Mastori provides the following features:
 

--- a/blog/views.py
+++ b/blog/views.py
@@ -9,6 +9,9 @@ from rest_framework.permissions import (AllowAny, IsAdminUser, IsAuthenticated,
 from rest_framework.response import Response
 from rest_framework.throttling import UserRateThrottle
 
+from drf_spectacular.utils import extend_schema,OpenApiParameter
+from drf_spectacular.types import OpenApiTypes
+
 from accounts.models import Account
 from blog.filters import StoriFilter
 from blog.models import Category, Comment, Stori
@@ -32,7 +35,7 @@ class CategoryViewset(viewsets.ModelViewSet):
             self.permission_classes = [AllowAny]
         return super().get_permissions()
     
-
+@extend_schema(responses=BlogSerializer)
 class StoriViewset(viewsets.ModelViewSet):
     """"blog/stori viewset"""
     serializer_class = BlogSerializer
@@ -44,6 +47,7 @@ class StoriViewset(viewsets.ModelViewSet):
         #account = Account.objects.get(user=self.request.user)
         serializer.save(created_by__user=self.request.user)
 
+@extend_schema(responses=BlogSerializer, parameters=[OpenApiParameter(name="id", type=OpenApiTypes.INT)])
 class DraftStoriViewset(viewsets.ModelViewSet):
     """"draft Stori viewset"""
     serializer_class = BlogSerializer
@@ -54,8 +58,7 @@ class DraftStoriViewset(viewsets.ModelViewSet):
         queryset = Stori.objects.filter(status="Draft", created_by__user=self.request.user)
         return queryset
 
-
-
+@extend_schema(responses=CommentSerializer, parameters=[ OpenApiParameter(name="mastori_pk", type=OpenApiTypes.INT)])
 class CommentViewset(viewsets.ModelViewSet):
     """comment viewset"""
     serializer_class = CommentSerializer

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,8 +24,10 @@ django-storages==1.13.2
 django-templated-email==3.0.1
 djangorestframework==3.14.0
 djangorestframework-simplejwt==5.2.2
+django-rest-swagger==2.2.0
 djoser==2.2.0
 drf-nested-routers==0.93.4
+drf-spectacular==0.26.4
 exceptiongroup==1.1.0
 gunicorn==20.1.0
 iniconfig==2.0.0


### PR DESCRIPTION
# Description
Intergrated use of swagger and drf spectacular for API documentation.
For an quick alternative to postman, swagger allows users to do all requests from the browser which is abit lightweight.

Dependecies
- drf-spectacular
- django-rest-swagger

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

[![CI Django & Postgres Tests](https://github.com/SpaceyaTech/blog/actions/workflows/django-postgres-ci.yml/badge.svg)](https://github.com/SpaceyaTech/blog/actions/workflows/django-postgres-ci.yml)

[![Jambo](https://github.com/SpaceyaTech/mastori/actions/workflows/jambo.yaml/badge.svg)](https://github.com/SpaceyaTech/mastori/actions/workflows/jambo.yaml)


**Test Configuration**:

```sql
          python manage.py migrate
          python manage.py test
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

