### PR TITLE
Update celery versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ __pycache__/
 # C extensions
 *.so
 
+# IDEA
+.idea/
+
 # Distribution / packaging
 .Python
 build/

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,11 @@ amqp==5.1.1
 asgiref==3.5.2
 async-timeout==4.0.2
 attrs==22.2.0
-billiard==3.6.4.0
+billiard==4.2.1
 black==22.12.0
 boto3==1.26.84
 botocore==1.29.84
-celery==5.2.7
+celery==5.4.0
 click==8.1.3
 click-didyoumean==0.3.0
 click-plugins==1.1.1
@@ -32,7 +32,7 @@ exceptiongroup==1.1.0
 gunicorn==20.1.0
 iniconfig==2.0.0
 jmespath==1.0.1
-kombu==5.2.4
+kombu==5.4.2
 model-bakery==1.9.0
 mypy-extensions==0.4.3
 packaging==23.0
@@ -53,8 +53,8 @@ s3transfer==0.6.0
 six==1.16.0
 sqlparse==0.4.3
 tomli==2.0.1
-tzdata==2022.6
+tzdata==2024.2
 urllib3==1.26.14
-vine==5.0.0
+vine==5.1.0
 wcwidth==0.2.6
 whitenoise==6.4.0


### PR DESCRIPTION
# Description

Was getting a `cannot import name 'Celery' from 'celery' ` error while trying to build the code
Similar to discussion here: https://github.com/python/importlib_metadata/issues/411

Updating the libraries involved unblocked me

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

[![CI Django & Postgres Tests](https://github.com/SpaceyaTech/blog/actions/workflows/django-postgres-ci.yml/badge.svg)](https://github.com/SpaceyaTech/blog/actions/workflows/django-postgres-ci.yml)

[![Jambo](https://github.com/SpaceyaTech/mastori/actions/workflows/jambo.yaml/badge.svg)](https://github.com/SpaceyaTech/mastori/actions/workflows/jambo.yaml)


**Test Configuration**:

```sql
          python manage.py migrate
          python manage.py test
```

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

